### PR TITLE
Updating goreleaser to v2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,6 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
@@ -57,4 +58,4 @@ release:
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:
-  skip: true
+  disable: true


### PR DESCRIPTION
Goreleaser now requires [version two](https://goreleaser.com/blog/goreleaser-v2/), which resulted in a failed build (logs in PR comments for posterity). [These docs](https://goreleaser.com/deprecations/) list the changes from V0 -> V1 -> V2. 

This PR updates our goReleaser config accordingly, and we've verified with the latest version in the [reference file in the framework repo](https://github.com/hashicorp/terraform-provider-scaffolding-framework/commit/18ad4fcb5bf872f3a841a15fc9a38da298a62bfe). 

`goreleaser check` now returns the following locally:
```
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
  ```